### PR TITLE
Swap use of virtual_host_alias and _name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -133,8 +133,8 @@ end
 default['jira']['apache2']['access_log']         = ''
 default['jira']['apache2']['error_log']          = ''
 default['jira']['apache2']['port']               = 80
-default['jira']['apache2']['virtual_host_alias'] = node['fqdn']
-default['jira']['apache2']['virtual_host_name']  = node['hostname']
+default['jira']['apache2']['virtual_host_name']  = node['fqdn']
+default['jira']['apache2']['virtual_host_alias'] = node['hostname']
 
 default['jira']['apache2']['ssl']['access_log']       = ''
 default['jira']['apache2']['ssl']['chain_file']       = ''

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -6,4 +6,4 @@ include_recipe 'apache2::mod_proxy'
 include_recipe 'apache2::mod_proxy_http'
 include_recipe 'apache2::mod_ssl'
 
-web_app node['jira']['apache2']['virtual_host_name']
+web_app node['jira']['apache2']['virtual_host_alias']

--- a/templates/default/tomcat/server.xml.erb
+++ b/templates/default/tomcat/server.xml.erb
@@ -60,7 +60,7 @@
                    redirectPort="<%= node['jira']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['jira']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= node['jira']['apache2']['virtual_host_name'] %>"
                    proxyPort="<%= node['jira']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['jira']['tomcat']['ssl_port'] %>"


### PR DESCRIPTION
Similar to https://github.com/bflad/chef-confluence/pull/47, swap usage of virtual_host_alias and _name.

According to Apache documentation, ServerName should be set to FQDN while ServerAlias can be just a hostname
